### PR TITLE
Initialize access_code at start

### DIFF
--- a/yubicrack.c
+++ b/yubicrack.c
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
 	}
 
 	yk = 0;
-	unsigned char access_code[6];
+	unsigned char access_code[6]={0};
 	const char* aeshash="00000000000000000000000000000000";
 	YKP_CONFIG *cfg = ykp_create_config();
 	YK_STATUS *st = ykds_alloc();


### PR DESCRIPTION
Thanks for the resume functionality! I was foolish enough to buy a spare yubikey from ebay, so really appreciate the ability to leave the crack attempt unattended.

When I started this on my machine for the first time, it began with a random value for the access code; I'm guessing this was a mistake.

Cheers!
Tom